### PR TITLE
Fix eslint throwing error for unused vars

### DIFF
--- a/src/FittedImage.js
+++ b/src/FittedImage.js
@@ -78,7 +78,9 @@ const FittedImage = React.createClass({
   },
 
   _getImage() {
+    /* eslint disable-no-unused-vars */
     const { background, src, onLoad, onError, ...props } = this.props;
+
     if ( !background && modern ) {
       return <img {...props} src={src} className={ this._getClassName(false) } />;
     } else {


### PR DESCRIPTION
It appears I've made an error in not disabling the no unused variables check in eslint. This commit fixes that so no errors are thrown on package install.