### PR TITLE
Added support for React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     ],
     "scriptPreprocessor": "<rootDir>/jest-preprocessor.js"
   },
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jest-cli": "^0.9.2",
     "node-sass": "^3.4.2",
     "postcss-loader": "^0.8.2",
+    "prop-types": "^15.6.0",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "^0.14.7",

--- a/src/FittedImage.js
+++ b/src/FittedImage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import loadImage from './utils/loadImage.js';
 import './FittedImage.scss';
@@ -18,14 +19,14 @@ const FittedImage = React.createClass({
   displayName: 'FittedImage',
 
   propTypes: {
-    background: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    fit: React.PropTypes.oneOf(['auto', 'contain', 'cover']),
-    loader: React.PropTypes.element,
-    src: React.PropTypes.string.isRequired,
-    style: React.PropTypes.object,
-    onLoad: React.PropTypes.func,
-    onError: React.PropTypes.func
+    background: PropTypes.bool,
+    className: PropTypes.string,
+    fit: PropTypes.oneOf(['auto', 'contain', 'cover']),
+    loader: PropTypes.element,
+    src: PropTypes.string.isRequired,
+    style: PropTypes.object,
+    onLoad: PropTypes.func,
+    onError: PropTypes.func
   },
 
   /* Lifecycle */


### PR DESCRIPTION
As of React v16.0, the `PropTypes` object is no longer supported therefore, the separate NPM package should be used in its place.